### PR TITLE
feat: non-interactive runs

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "Debian",
+	"image": "mcr.microsoft.com/vscode/devcontainers/base:debian-12",
+	"features": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"richterger.perl",
+				"GitHub.vscode-github-actions",
+				"jetmartin.bats"
+			]
+		}
+	}
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian-12
+
+RUN apt-get update && apt-get install -y \
+  libanyevent-perl \
+  libclass-refresh-perl \
+  libcompiler-lexer-perl \
+  libdata-dump-perl \
+  libio-aio-perl \
+  libjson-perl \
+  libmoose-perl \
+  libpadwalker-perl \
+  libscalar-list-utils-perl \
+  libcoro-perl
+
+ARG PERL_MM_USE_DEFAULT=1
+RUN cpan Perl::LanguageServer

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,3 +14,4 @@ RUN apt-get update && apt-get install -y \
 
 ARG PERL_MM_USE_DEFAULT=1
 RUN cpan Perl::LanguageServer
+RUN cpan Perl::Tidy

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:debian-12
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian-11
 
 RUN apt-get update && apt-get install -y \
   libanyevent-perl \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "Debian",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"richterger.perl",
+				"GitHub.vscode-github-actions",
+				"jetmartin.bats"
+			]
+		}
+	},
+	"postStartCommand": {
+		"safe-dir": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ inc/
 # End of https://www.toptal.com/developers/gitignore/api/perl
 
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+
+# Perl language server cache
+.vscode/perl-lang

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,44 @@
-*.swp
-.AppleDouble
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/perl
+# Edit at https://www.toptal.com/developers/gitignore?templates=perl
+
+### Perl ###
+!Build/
+.last_cover_stats
+/META.yml
+/META.json
+/MYMETA.*
+*.o
+*.pm.tdy
+*.bs
+
+# Devel::Cover
+cover_db/
+
+# Devel::NYTProf
+nytprof.out
+
+# Dist::Zilla
+/.build/
+
+# Module::Build
+_build/
+Build
+Build.bat
+
+# Module::Install
+inc/
+
+# ExtUtils::MakeMaker
+/blib/
+/_eumm/
+/*.gz
+/Makefile
+/Makefile.old
+/MANIFEST.bak
+/pm_to_blib
+/*.zip
+
+# End of https://www.toptal.com/developers/gitignore/api/perl
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)

--- a/samples/bottles.vq
+++ b/samples/bottles.vq
@@ -1,3 +1,5 @@
+#! /usr/bin/perl /workspaces/varaq/varaq-kling
+
 (* bloodwine.vq -- 99 bottles of bloodwine in varaq-engl *)
 
 ~ bloodwine { "bottles of bloodwine" cha' } pong
@@ -13,7 +15,7 @@
 	latlh latlh cha' bloodwine
 	fall
 	latlh 0 law''a'
-		{ wa'teq bottles } HIja'chugh
+		{ wa'boqHa' bottles } HIja'chugh
 } pong
 
 99 bottles

--- a/samples/bottles.vqe
+++ b/samples/bottles.vqe
@@ -1,3 +1,5 @@
+#! /usr/bin/perl /workspaces/varaq/varaq-engl
+
 (* bloodwine.vqe -- 99 bottles of bloodwine in varaq-engl *)
 
 ~ bloodwine { "bottles of bloodwine" disp } name

--- a/samples/fact.vqe
+++ b/samples/fact.vqe
@@ -1,4 +1,4 @@
-
+#! /usr/bin/perl /workspaces/varaq/varaq-engl
 
 (* factorial.vqe *)
 

--- a/translators/varaq.dict
+++ b/translators/varaq.dict
@@ -1,1 +1,130 @@
-# var'aq dictionary## File Format Notes:# 1. Lines that begin with # are comments; empty lines can be ignored.# 2. Data lines contain multiple entries separated by tabs.# 3. Alternatives within a particular language are separated by the | #    character; for purposes of machine translation, the first form#    listed is preferred.# 4. The first data line contains language codes.  Where these #    represent natural human languages, conformance with RFC1766 is #    recommended.  #  * Note potential conflict: kl has been used for Klingon, but is #    officially assigned in ISO639 to Greenlandic, an Eskimo language.en	kl|tlh# *** Data Types ***# (* probably not necessary in this file *)number	mI'function	jangwI'list	ghomHomstring	tlhegh# *** Language Basics ***# Stack Operationspop	woDdup	latlhexch	tamclear	chImmoHremember	qawforget	qawHa'dump	Hotlh# Data/Code Operations~	~|li'moHname	pongset	cher# Control Flowifyes	HIja'chughifno	ghobe'chughchoose	wIveval	chovescape	narghrepeat	vangqa'# List Operationssplit	SIjcons	muvshatter	ghorqu'empty?	chIm'a'# String Operatorsstrcat	tlheghrarcompose	naQmoHstreq?	tlhreghrap'a'strcut	tlheghpe'strmeasure	tlheghjuvexplode	jor# *** Mathematical Operators ***# Arithmetic Operatorsadd	chelsub	teqmul	law'moHdiv	wavidiv	Habwavmod	chuvpow	law'qa'moHsqrt	loS'aradd1	wa'chelsub1	wa'teq# Trigonometric and Logarithmic Operatorssin	joqcos	joqHa'tan	qojmI'atan	qojHa'ln	ghurtaHlog	maHghurtaHlog3	wejghurtaH# Numerical Operations and Constantssetrand	mIScherrand	mISpi	HeHmI'e	ghurmI'int?	HabmI''a'number?	mI''a'numberize	mi'moH# Bitwise Operatorsisolate	mobmoHmix	DuDcontradict	tlhochcompl	Qo'moHshiftright	nIHghoSshiftleft	poSghoS# *** Relational and Logical Operators ***# Relational Operatorsgt?	law''a'lt?	puS'a'eq?	rap'a'ge?	law'rap'a'le?	puSrap'a'ne?	rapbe'a'null?	pagh'a'negative?	taH'a'# Logical Operatorsand	jeor	joqxor	ghap# *** Input/Output and File Operators ***# Console I/Odisp	cha'listen	'Ijcomplain	bep
+# var'aq dictionary
+#
+# File Format Notes:
+# 1. Lines that begin with # are comments; empty lines can be ignored.
+# 2. Data lines contain multiple entries separated by tabs.
+# 3. Alternatives within a particular language are separated by the | 
+#    character; for purposes of machine translation, the first form
+#    listed is preferred.
+# 4. The first data line contains language codes.  Where these 
+#    represent natural human languages, conformance with RFC1766 is 
+#    recommended.  
+#  * Note potential conflict: kl has been used for Klingon, but is 
+#    officially assigned in ISO639 to Greenlandic, an Eskimo language.
+
+
+en	kl|tlh
+
+
+# *** Data Types ***
+# (* probably not necessary in this file *)
+number	mI'
+function	jangwI'
+list	ghomHom
+string	tlhegh
+
+
+# *** Language Basics ***
+
+# Stack Operations
+pop	woD
+dup	latlh
+exch	tam
+clear	chImmoH
+remember	qaw
+forget	qawHa'
+dump	Hotlh
+
+# Data/Code Operations
+~	~|li'moH
+name	pong
+set	cher
+
+# Control Flow
+ifyes	HIja'chugh
+ifno	ghobe'chugh
+choose	wIv
+eval	chov
+escape	nargh
+repeat	vangqa'
+
+# List Operations
+split	SIj
+cons	muv
+shatter	ghorqu'
+empty?	chIm'a'
+
+# String Operators
+strcat	tlheghrar
+compose	naQmoH
+streq?	tlhreghrap'a'
+strcut	tlheghpe'
+strmeasure	tlheghjuv
+explode	jor
+
+
+# *** Mathematical Operators ***
+
+# Arithmetic Operators
+add	chel
+sub	teq
+mul	law'moH
+div	wav
+idiv	Habwav
+mod	chuv
+pow	law'qa'moH
+sqrt	loS'ar
+add1	wa'chel
+sub1	wa'boqHa'
+
+# Trigonometric and Logarithmic Operators
+sin	joq
+cos	joqHa'
+tan	qojmI'
+atan	qojHa'
+ln	ghurtaH
+log	maHghurtaH
+log3	wejghurtaH
+
+# Numerical Operations and Constants
+setrand	mIScher
+rand	mIS
+pi	HeHmI'
+e	ghurmI'
+int?	HabmI''a'
+number?	mI''a'
+numberize	mi'moH
+
+# Bitwise Operators
+isolate	mobmoH
+mix	DuD
+contradict	tlhoch
+compl	Qo'moH
+shiftright	nIHghoS
+shiftleft	poSghoS
+
+
+# *** Relational and Logical Operators ***
+
+# Relational Operators
+gt?	law''a'
+lt?	puS'a'
+eq?	rap'a'
+ge?	law'rap'a'
+le?	puSrap'a'
+ne?	rapbe'a'
+null?	pagh'a'
+negative?	taH'a'
+
+# Logical Operators
+and	je
+or	joq
+xor	ghap
+
+
+# *** Input/Output and File Operators ***
+
+# Console I/O
+disp	cha'
+listen	'Ij
+complain	bep

--- a/varaq-engl
+++ b/varaq-engl
@@ -41,7 +41,7 @@ RestartScan:
 
   while ($line =~ /^\s*$/)  # Get next line if we used up the current line
   {
-    $line = <STDIN>;
+    $line = ( $stream_choice eq "stdin" ) ? <STDIN> : <FH>;
     return undef if not defined $line;
     chomp $line;
     $line =~ s/^\s*//;
@@ -188,7 +188,7 @@ sub execute {
 # from somewhere, yes?
 
 	} elsif ($cmd eq 'listen') {
-		$in = <STDIN>;
+    $in = ( $stream_choice eq "stdin" ) ? <STDIN> : <FH>;
 		push @{$stack}, $in;
 
 # This may seem redundant, but a careful reading of the code indicates
@@ -526,7 +526,7 @@ sub execute {
 		else {
 			while ($cval > 0) {
 				execblock();
-				if ($escv = 1) {
+				if ($escv == 1) {
 					$cval = 1;
 					$escv = 0;
 				}
@@ -635,9 +635,18 @@ sub execute {
 if ( -t STDIN and not @ARGV ) {
     print "var'aq Reference Edition -- English v0.5\n";
     print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+    $stream_choice = "stdin";
+    $token         = token();
+    parse();
 }
-$token = token();
-parse();
+else {
+    my $filename = $ARGV[0];
+    $stream_choice = "file";
+    open( FH, '<', $filename ) or die $!;
+    $token = token();
+    parse();
+    close(FH);
+}
 
 ### END ###
 

--- a/varaq-engl
+++ b/varaq-engl
@@ -635,6 +635,9 @@ sub execute {
 if ( -t STDIN and not @ARGV ) {
     print "var'aq Reference Edition -- English v0.5\n";
     print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+}
+elsif ( not @ARGV ) {
+    my $filename = $ARGV[0];
     $stream_choice = "stdin";
     $token         = token();
     parse();

--- a/varaq-engl
+++ b/varaq-engl
@@ -632,8 +632,10 @@ sub execute {
 
 ### MAIN ###
 
-print "var'aq Reference Edition -- English v0.5\n";
-print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+if ( -t STDIN and not @ARGV ) {
+    print "var'aq Reference Edition -- English v0.5\n";
+    print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+}
 $token = token();
 parse();
 

--- a/varaq-kling
+++ b/varaq-kling
@@ -41,7 +41,7 @@ RestartScan:
 
   while ($line =~ /^\s*$/)  # Get next line if we used up the current line
   {
-    $line = <STDIN>;
+    $line = ( $stream_choice eq "stdin" ) ? <STDIN> : <FH>;
     return undef if not defined $line;
     chomp $line;
     $line =~ s/^\s*//;
@@ -188,7 +188,7 @@ sub execute {
 # from somewhere, yes?
 
 	} elsif ($cmd eq "'Ij") {
-		$in = <STDIN>;
+    $in = ( $stream_choice eq "stdin" ) ? <STDIN> : <FH>;
 		push @{$stack}, $in;
 
 # This may seem redundant, but a careful reading of the code indicates
@@ -526,7 +526,7 @@ sub execute {
 		else {
 			while ($cval > 0) {
 				execblock();
-				if ($escv = 1) {
+				if ($escv == 1) {
 					$cval = 1;
 					$escv = 0;
 				}
@@ -635,9 +635,18 @@ sub execute {
 if ( -t STDIN and not @ARGV ) {
     print "var'aq Reference Edition -- Klingon v0.5\n";
     print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+    $stream_choice = "stdin";
+    $token         = token();
+    parse();
 }
-$token = token();
-parse();
+else {
+    my $filename = $ARGV[0];
+    $stream_choice = "file";
+    open( FH, '<', $filename ) or die $!;
+    $token = token();
+    parse();
+    close(FH);
+}
 
 ### END ###
 

--- a/varaq-kling
+++ b/varaq-kling
@@ -635,8 +635,11 @@ sub execute {
 if ( -t STDIN and not @ARGV ) {
     print "var'aq Reference Edition -- Klingon v0.5\n";
     print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+}
+elsif (not @ARGV) {
+    my $filename = $ARGV[0];
     $stream_choice = "stdin";
-    $token         = token();
+    $token = token();
     parse();
 }
 else {

--- a/varaq-kling
+++ b/varaq-kling
@@ -632,8 +632,10 @@ sub execute {
 
 ### MAIN ###
 
-print "var'aq Reference Edition -- Klingon v0.5\n";
-print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+if ( -t STDIN and not @ARGV ) {
+    print "var'aq Reference Edition -- Klingon v0.5\n";
+    print "(c)2000 Brian Connors, Chris Pressey, and Mark Shoulson\n\n";
+}
 $token = token();
 parse();
 


### PR DESCRIPTION
This PR enables va'raq to be run non-interactively with a script the usual way (by passing the file in as `$1` or using shebang) instead of having to use shell redirection to pass files in via stdin. The usual header lines printed on interactive use are suppressed if either stdin or a file argument are supplied.

The use case for this was to simplify using va'raq in CGI scripts. Please don't ask.

In addition, there are a few additional changes:

- A [devcontainer](https://containers.dev) configuration has been added, which allows for dependencies to be described programmatically without need to install them locally on supported IDEs (such as Visual Studio Code and IntelliJ).
- The gitignore file has been regenerated using the Perl sample from <https://gitignore.io>.
- Shebangs and permissions have been updated on test files.
- `sub1` was actually broken in Klingon, in both the test case and the translator. The function in the Klingon source is named `wa'boqHa'` but it was given as `wa'teq` in those files, meaning the sample didn't run.
- One minor equality fix (thanks `-W`).